### PR TITLE
feat: add handling bzip2 compressed streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/zkochan/unpack-stream#readme",
   "dependencies": {
     "@types/node": "^6.0.45",
-    "gunzip-maybe": "^1.3.1",
+    "decompress-maybe": "^1.0.0",
     "tar-fs": "^1.14.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import crypto = require('crypto')
-import gunzip = require('gunzip-maybe')
+import decompress = require('decompress-maybe')
 import tar = require('tar-fs')
 import {IncomingMessage} from 'http'
 
@@ -58,7 +58,7 @@ export function remote (stream: IncomingMessage, dest: string, opts: UnpackRemot
 export function local (stream: NodeJS.ReadableStream, dest: string) {
   return new Promise((resolve, reject) => {
     stream
-      .pipe(gunzip()).on('error', reject)
+      .pipe(decompress()).on('error', reject)
       .pipe(tar.extract(dest, { strip: 1 })).on('error', reject)
       .on('finish', resolve)
   })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'gunzip-maybe' {
+declare module 'decompress-maybe' {
   const anything: any;
   export = anything;
 }


### PR DESCRIPTION
This makes `unpack-stream` work with bzip2 compressed streams!